### PR TITLE
fix:  now HC.hash() is usable

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -154,5 +154,5 @@ return setmetatable({
 	neighbors  = function(...) return instance:neighbors(...) end,
 	collisions = function(...) return instance:collisions(...) end,
 	shapesAt   = function(...) return instance:shapesAt(...) end,
-	hash       = function() return instance.hash() end,
+	hash       = function() return instance:hash() end,
 }, {__call = function(_, ...) return common_local.instance(HC, ...) end})


### PR DESCRIPTION
it was the only method to be  `instance.` instead of `instance:`

as you have the most recent fork of  HC,  it's worth a shot to propose you this bugfix